### PR TITLE
Convert API to async/await

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,6 +3,10 @@
 
 import PackageDescription
 
+let settings: [SwiftSetting] = [
+    .enableExperimentalFeature("StrictConcurrency")
+]
+
 let package = Package(
     name: "CachingMapKitTileOverlay",
     platforms: [
@@ -22,10 +26,13 @@ let package = Package(
         // Targets are the basic building blocks of a package, defining a module or a test suite.
         // Targets can depend on other targets in this package and products from dependencies.
         .target(
-            name: "CachingMapKitTileOverlay"),
+            name: "CachingMapKitTileOverlay",
+            swiftSettings: settings
+        ),
         .testTarget(
             name: "CachingMapKitTileOverlayTests",
-            dependencies: ["CachingMapKitTileOverlay"]
+            dependencies: ["CachingMapKitTileOverlay"],
+            swiftSettings: settings
         ),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,13 @@ import PackageDescription
 
 let package = Package(
     name: "CachingMapKitTileOverlay",
+    platforms: [
+        .iOS(.v13),
+        .macOS(.v10_15),
+        .watchOS(.v6),
+        .tvOS(.v13),
+        .visionOS(.v1)
+    ],
     products: [
         // Products define the executables and libraries a package produces, making them visible to other packages.
         .library(

--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@
 import PackageDescription
 
 let settings: [SwiftSetting] = [
-    .enableExperimentalFeature("StrictConcurrency")
+    .enableExperimentalFeature("StrictConcurrency"),
 ]
 
 let package = Package(
@@ -14,13 +14,14 @@ let package = Package(
         .macOS(.v10_15),
         .watchOS(.v6),
         .tvOS(.v13),
-        .visionOS(.v1)
+        .visionOS(.v1),
     ],
     products: [
         // Products define the executables and libraries a package produces, making them visible to other packages.
         .library(
             name: "CachingMapKitTileOverlay",
-            targets: ["CachingMapKitTileOverlay"]),
+            targets: ["CachingMapKitTileOverlay"]
+        ),
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.

--- a/Sources/CachingMapKitTileOverlay/CachingTileOverlay.swift
+++ b/Sources/CachingMapKitTileOverlay/CachingTileOverlay.swift
@@ -11,7 +11,7 @@ public protocol CachingTileOverlay: MKOverlay {
     ///
     /// This method should retorn as quickly as possible.
     func cachedData(at path: MKTileOverlayPath) -> Data?
-    func loadTile(at path: MKTileOverlayPath, result: @escaping (Data?, (any Error)?) -> Void)
+    func loadTile(at path: MKTileOverlayPath) async throws -> Data
 
     var tileSize: CGSize { get }
 }

--- a/Sources/CachingMapKitTileOverlay/CachingTileOverlayRenderer.swift
+++ b/Sources/CachingMapKitTileOverlay/CachingTileOverlayRenderer.swift
@@ -96,15 +96,13 @@ public class CachingTileOverlayRenderer: MKOverlayRenderer {
         guard !loadingTiles.contains(tileKey) else { return }
 
         loadingTiles.insert(tileKey)
-
-        overlay.loadTile(at: path) { [weak self] data, error in
-            guard let self = self else { return }
-            self.loadingTiles.remove(tileKey)
-
+        
+        Task { [weak self] in
+            _ = try? await overlay.loadTile(at: path)
+            self?.loadingTiles.remove(tileKey)
+            
             // When the tile has loaded, schedule a redraw of the tile region.
-            DispatchQueue.main.async {
-                self.setNeedsDisplay(tileMapRect)
-            }
+            self?.setNeedsDisplay(tileMapRect)
         }
     }
 

--- a/Sources/CachingMapKitTileOverlay/CachingTileOverlayRenderer.swift
+++ b/Sources/CachingMapKitTileOverlay/CachingTileOverlayRenderer.swift
@@ -1,9 +1,9 @@
 import MapKit
 
 #if canImport(UIKit)
-typealias ImageType = UIImage
+    typealias ImageType = UIImage
 #elseif canImport(AppKit)
-typealias ImageType = NSImage
+    typealias ImageType = NSImage
 #endif
 
 /// A tile overlay renderer that uses a custom cache
@@ -18,7 +18,7 @@ public class CachingTileOverlayRenderer: MKOverlayRenderer {
         super.init(overlay: overlay)
     }
 
-    public override func draw(_ mapRect: MKMapRect, zoomScale: MKZoomScale, in context: CGContext) {
+    override public func draw(_ mapRect: MKMapRect, zoomScale: MKZoomScale, in context: CGContext) {
         // Shift the type; our constructor ensures we can't get this wrong by accident though.
         guard let tileOverlay = overlay as? CachingTileOverlay else {
             fatalError("The overlay must implement MKCachingTileOverlay")
@@ -34,25 +34,25 @@ public class CachingTileOverlayRenderer: MKOverlayRenderer {
         let offsetY = overlayRect.origin.y
 
         let firstCol = Int(floor((mapRect.origin.x - offsetX) / tileMapSize))
-        let lastCol  = Int(floor((mapRect.maxX - offsetX) / tileMapSize))
+        let lastCol = Int(floor((mapRect.maxX - offsetX) / tileMapSize))
         let firstRow = Int(floor((mapRect.origin.y - offsetY) / tileMapSize))
-        let lastRow  = Int(floor((mapRect.maxY - offsetY) / tileMapSize))
+        let lastRow = Int(floor((mapRect.maxY - offsetY) / tileMapSize))
 
         // Calculate the current zoom level
-        let currentZoom = self.zoomLevel(for: zoomScale)
+        let currentZoom = zoomLevel(for: zoomScale)
 
         // Loop over the tiles that intersect mapRect...
-        for x in firstCol...lastCol {
-            for y in firstRow...lastRow {
+        for x in firstCol ... lastCol {
+            for y in firstRow ... lastRow {
                 // Compute the mapRect for this tile
                 let tileOriginX = Double(x) * tileMapSize
                 let tileOriginY = Double(y) * tileMapSize
                 let tileRect = MKMapRect(x: tileOriginX, y: tileOriginY, width: tileMapSize, height: tileMapSize)
 
                 // Create the tile overlay path
-                let tilePath = MKTileOverlayPath(x: x, y: y, z: currentZoom, contentScaleFactor: self.contentScaleFactor)
+                let tilePath = MKTileOverlayPath(x: x, y: y, z: currentZoom, contentScaleFactor: contentScaleFactor)
 
-                let drawRect = self.rect(for: tileRect)
+                let drawRect = rect(for: tileRect)
 
                 if let image = cachedTileImage(for: tilePath) {
                     // If we have a cached image for this tile, just draw it!
@@ -88,7 +88,7 @@ public class CachingTileOverlayRenderer: MKOverlayRenderer {
     }
 
     func loadTileIfNeeded(for path: MKTileOverlayPath, in tileMapRect: MKMapRect) {
-        guard let overlay = self.overlay as? CachingTileOverlay else { return }
+        guard let overlay = overlay as? CachingTileOverlay else { return }
 
         // Create a unique key for the tile (MKTileOverlayPath is not hashable)
         // and use this to avoid duplicate requests.
@@ -96,18 +96,18 @@ public class CachingTileOverlayRenderer: MKOverlayRenderer {
         guard !loadingTiles.contains(tileKey) else { return }
 
         loadingTiles.insert(tileKey)
-        
+
         Task { [weak self] in
             _ = try? await overlay.loadTile(at: path)
             self?.loadingTiles.remove(tileKey)
-            
+
             // When the tile has loaded, schedule a redraw of the tile region.
             self?.setNeedsDisplay(tileMapRect)
         }
     }
 
     func cachedTileImage(for path: MKTileOverlayPath) -> ImageType? {
-        guard let overlay = self.overlay as? CachingTileOverlay else { return nil }
+        guard let overlay = overlay as? CachingTileOverlay else { return nil }
         if let data = overlay.cachedData(at: path) {
             return ImageType(data: data)
         }
@@ -135,20 +135,20 @@ public class CachingTileOverlayRenderer: MKOverlayRenderer {
     }
 
     func drawImage(_ image: ImageType, in rect: CGRect, context: CGContext) {
-#if canImport(UIKit)
-        UIGraphicsPushContext(context)
+        #if canImport(UIKit)
+            UIGraphicsPushContext(context)
 
-        image.draw(in: rect)
+            image.draw(in: rect)
 
-        UIGraphicsPopContext()
-#elseif canImport(AppKit)
-        let graphicsContext = NSGraphicsContext(cgContext: context, flipped: true)
+            UIGraphicsPopContext()
+        #elseif canImport(AppKit)
+            let graphicsContext = NSGraphicsContext(cgContext: context, flipped: true)
 
-        NSGraphicsContext.saveGraphicsState()
-        NSGraphicsContext.current = graphicsContext
-        image.draw(in: rect)
-        NSGraphicsContext.restoreGraphicsState()
-#endif
+            NSGraphicsContext.saveGraphicsState()
+            NSGraphicsContext.current = graphicsContext
+            image.draw(in: rect)
+            NSGraphicsContext.restoreGraphicsState()
+        #endif
     }
 }
 

--- a/Sources/CachingMapKitTileOverlay/Cropping.swift
+++ b/Sources/CachingMapKitTileOverlay/Cropping.swift
@@ -1,40 +1,41 @@
 #if canImport(UIKit)
-import UIKit
+    import UIKit
 
-extension UIImage {
-    /// Returns a new image by cropping to the specified rect (in the image’s point coordinate space).
-    func cropped(to rect: CGRect) -> UIImage? {
-        // Create an image context of the desired size.
-        UIGraphicsBeginImageContextWithOptions(rect.size, false, self.scale)
-        // Draw the image, offsetting by the negative origin of the cropping rect.
-        self.draw(at: CGPoint(x: -rect.origin.x, y: -rect.origin.y))
-        let croppedImage = UIGraphicsGetImageFromCurrentImageContext()
-        UIGraphicsEndImageContext()
-        return croppedImage
+    extension UIImage {
+        /// Returns a new image by cropping to the specified rect (in the image’s point coordinate space).
+        func cropped(to rect: CGRect) -> UIImage? {
+            // Create an image context of the desired size.
+            UIGraphicsBeginImageContextWithOptions(rect.size, false, scale)
+            // Draw the image, offsetting by the negative origin of the cropping rect.
+            draw(at: CGPoint(x: -rect.origin.x, y: -rect.origin.y))
+            let croppedImage = UIGraphicsGetImageFromCurrentImageContext()
+            UIGraphicsEndImageContext()
+            return croppedImage
+        }
     }
-}
+
 #elseif canImport(AppKit)
-import AppKit
+    import AppKit
 
-extension NSImage {
-    /// Returns a new image by cropping self to the specified rect.
-    /// The cropRect is assumed to be defined in a UIKit-style coordinate system (origin at top‑left).
-    func cropped(to cropRect: CGRect) -> NSImage? {
-        return NSImage(size: cropRect.size, flipped: true, drawingHandler: { bounds in
-            let drawingRect = NSRect(
-                x: -cropRect.origin.x,
-                y: -cropRect.origin.y,
-                width: self.size.width,
-                height: self.size.height
-            )
-            self.draw(in: drawingRect,
-                      from: NSRect(origin: .zero, size: self.size),
-                      operation: .copy,
-                      fraction: 1.0,
-                      respectFlipped: true,
-                      hints: nil)
-            return true
-        })
+    extension NSImage {
+        /// Returns a new image by cropping self to the specified rect.
+        /// The cropRect is assumed to be defined in a UIKit-style coordinate system (origin at top‑left).
+        func cropped(to cropRect: CGRect) -> NSImage? {
+            return NSImage(size: cropRect.size, flipped: true, drawingHandler: { _ in
+                let drawingRect = NSRect(
+                    x: -cropRect.origin.x,
+                    y: -cropRect.origin.y,
+                    width: self.size.width,
+                    height: self.size.height
+                )
+                self.draw(in: drawingRect,
+                          from: NSRect(origin: .zero, size: self.size),
+                          operation: .copy,
+                          fraction: 1.0,
+                          respectFlipped: true,
+                          hints: nil)
+                return true
+            })
+        }
     }
-}
 #endif

--- a/Sources/CachingMapKitTileOverlay/Parent Tile.swift
+++ b/Sources/CachingMapKitTileOverlay/Parent Tile.swift
@@ -4,6 +4,6 @@ extension MKTileOverlayPath {
     var parent: MKTileOverlayPath {
         let newX = x % 2 == 0 ? (x / 2) : ((x - 1) / 2)
         let newY = y % 2 == 0 ? (y / 2) : ((y - 1) / 2)
-        return MKTileOverlayPath(x: newX, y: newY, z: z - 1, contentScaleFactor: self.contentScaleFactor)
+        return MKTileOverlayPath(x: newX, y: newY, z: z - 1, contentScaleFactor: contentScaleFactor)
     }
 }

--- a/Tests/CachingMapKitTileOverlayTests/CachingMapKitTileOverlayTests.swift
+++ b/Tests/CachingMapKitTileOverlayTests/CachingMapKitTileOverlayTests.swift
@@ -1,5 +1,5 @@
-import Testing
 @testable import CachingMapKitTileOverlay
+import Testing
 
 @Test func example() async throws {
     // Write your test here and use APIs like `#expect(...)` to check expected conditions.


### PR DESCRIPTION
Thanks for the great investigation and work on this! I enjoyed reading your blog post.

This PR converts the `CachingTileOverlay` API to be async instead of callback-based to better align with modern Swift APIs. To use async/await without branching the interface, the package needs OS constraints. Restricting to OSes in the last ~5 years seemed reasonable to me. I also enabled strict concurrency checking in the package to maintain greatest compliance with Swift 6.

If you'd like to maintain compatibility with older OSes or prefer the callbacks to async/await, feel free to reject this.